### PR TITLE
Jekyll build

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,7 @@ way. The latter is recommended.
 ### Build tunasync and nginx docker images
 
 ```sh
-$ cd tunasync
-$ docker build -t sjtug/mirror-tunasync .
-$ cd ../nginx
-$ docker build -t sjtug/mirror-nginx .
+$ utils/prepare.sh
 ```
 
 ### Run docker containers

--- a/jekyll/Dockerfile
+++ b/jekyll/Dockerfile
@@ -1,12 +1,6 @@
-FROM ubuntu:xenial
-MAINTAINER VicLuo
-ADD apt_sources.list /etc/apt/sources.list
+FROM sjtug/jekyll-base:2016-04-07
 
-# zlib is required by jekyll
-RUN apt-get update && apt-get install -y \
-	bundler \
-	jekyll \
-	zlib1g-dev
+MAINTAINER VicLuo
 
 ADD mirror-web /home/mirror-web
 

--- a/jekyll/Dockerfile
+++ b/jekyll/Dockerfile
@@ -2,7 +2,7 @@ FROM sjtug/jekyll-base:2016-04-07
 
 MAINTAINER VicLuo
 
-ADD mirror-web /home/mirror-web
+VOLUME ["/home/mirror-web"]
 
 WORKDIR /home/mirror-web
 

--- a/jekyll/build.sh
+++ b/jekyll/build.sh
@@ -1,11 +1,5 @@
-cd tunasync
-../utils/genpack.sh tunasync
-cd ..
-
-cd jekyll
 ../utils/genpack.sh mirror-web
-docker build -t sjtug/mirror-jekyll-builder .
-cd ..
+docker build -t sjtug/mirror-jekyll-builder:latest -t sjtug/mirror-jekyll-builder:`date -Idate` .
 
 # http://www.projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/
 mkdir -p /home/mirror-web/_site
@@ -13,3 +7,4 @@ docker run \
     -v /home/mirror-web/_site:/opt/_site:Z \
     sjtug/mirror-jekyll-builder:latest \
     jekyll build -d /opt/_site
+

--- a/jekyll/build.sh
+++ b/jekyll/build.sh
@@ -5,6 +5,7 @@ docker build -t sjtug/mirror-jekyll-builder:latest -t sjtug/mirror-jekyll-builde
 mkdir -p /home/mirror-web/_site
 docker run \
     -v /home/mirror-web/_site:/opt/_site:Z \
+    -v ./mirror-web:/home/mirror-web:Z \
     sjtug/mirror-jekyll-builder:latest \
     jekyll build -d /opt/_site
 

--- a/nginx/build.sh
+++ b/nginx/build.sh
@@ -1,0 +1,2 @@
+docker build -t sjtug/mirror-nginx:latest -t sjtug/mirror-nginx:`date -Idate` .
+

--- a/tunasync/build.sh
+++ b/tunasync/build.sh
@@ -1,0 +1,3 @@
+../utils/genpack.sh tunasync
+docker build -t sjtug/mirror-tunasync:latest -t sjtug/mirror-tunasync:`date -Idate` .
+

--- a/utils/prepare.sh
+++ b/utils/prepare.sh
@@ -1,0 +1,12 @@
+cd tunasync
+bash build.sh
+cd ..
+
+cd nginx
+bash build.sh
+cd ..
+
+cd jekyll
+bash build.sh
+cd ..
+


### PR DESCRIPTION
在外面创建了 image base，现在速度就快多了

不过，我想到一个问题：为什么我们要把（可能）频繁变化的 web 用 ADD 指令加入 image 呢？直接用共享 volume，就能在 image 不变的情况下编译 jekyll

（之前没人想到这一点吗？）
