### PR TITLE
fix jekyll build.sh relative path issue

### DIFF
--- a/jekyll/build.sh
+++ b/jekyll/build.sh
@@ -5,7 +5,7 @@ docker build -t sjtug/mirror-jekyll-builder:latest -t sjtug/mirror-jekyll-builde
 mkdir -p /home/mirror-web/_site
 docker run \
     -v /home/mirror-web/_site:/opt/_site:Z \
-    -v ./mirror-web:/home/mirror-web:Z \
+    -v $PWD/mirror-web:/home/mirror-web:Z \
     sjtug/mirror-jekyll-builder:latest \
     jekyll build -d /opt/_site
 


### PR DESCRIPTION
When I tried deploying the containers on mirrors.sjtug.org server,
docker gave the following error message:

docker: Error response from daemon: create ./mirror-web: volume name
invalid:
"./mirror-web" includes invalid characters for a local volume name, only
"[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed.
See 'docker run --help'.

Docker didn't seem to accept relative path for host directory. This
trouble should be caused by using different versions of docker in
development and deployment.

To fix this, use $PWD to get the absolute path instead.
