### PR TITLE
remove matsci channel, because main pkgs merge to forge

### DIFF
--- a/lug/config.example.yaml
+++ b/lug/config.example.yaml
@@ -182,10 +182,6 @@ repos:
       cloud/menpo/linux-64: https://conda.anaconda.org/menpo/linux-64/
       cloud/menpo/osx-64: https://conda.anaconda.org/menpo/osx-64/
       cloud/menpo/win-64: https://conda.anaconda.org/menpo/win-64/
-      cloud/matsci/noarch: https://conda.anaconda.org/matsci/noarch/
-      cloud/matsci/linux-64: https://conda.anaconda.org/matsci/linux-64/
-      cloud/matsci/osx-64: https://conda.anaconda.org/matsci/osx-64/
-      cloud/matsci/win-64: https://conda.anaconda.org/matsci/win-64/
       cloud/soumith/linux-64: https://conda.anaconda.org/soumith/linux-64/
       cloud/soumith/osx-64: https://conda.anaconda.org/soumith/osx-64/
       cloud/soumith/noarch: https://conda.anaconda.org/soumith/noarch/

--- a/lug/config.example.yaml
+++ b/lug/config.example.yaml
@@ -182,9 +182,10 @@ repos:
       cloud/menpo/linux-64: https://conda.anaconda.org/menpo/linux-64/
       cloud/menpo/osx-64: https://conda.anaconda.org/menpo/osx-64/
       cloud/menpo/win-64: https://conda.anaconda.org/menpo/win-64/
-      cloud/soumith/linux-64: https://conda.anaconda.org/soumith/linux-64/
-      cloud/soumith/osx-64: https://conda.anaconda.org/soumith/osx-64/
-      cloud/soumith/noarch: https://conda.anaconda.org/soumith/noarch/
+      cloud/pytorch/linux-64: https://conda.anaconda.org/pytorch/linux-64/
+      cloud/pytorch/osx-64: https://conda.anaconda.org/pytorch/osx-64/
+      cloud/pytorch/noarch: https://conda.anaconda.org/pytorch/noarch/
+      cloud/pytorch/win-64: https://conda.anaconda.org/pytorch/win-64/
     - type: external
       name: rust-static
       proxy_to: https://static.rust-lang.org/


### PR DESCRIPTION
I requested the anaconda mirror and mentioned the matsci channel for our materials-project packages. But now, the main packages of materials-project have been merged into the conda-forge channel, I'm convinced that I have no longer need matsci channel, so I remove it from the sjtug.

Maybe you also need to remove the files manually.